### PR TITLE
feat: Inactive sessions based cleanup added

### DIFF
--- a/mcp/spotify-mcp-oauth-http.js
+++ b/mcp/spotify-mcp-oauth-http.js
@@ -74,7 +74,13 @@ function cleanupInactiveSessions() {
 }
 
 // Start cleanup interval
-setInterval(cleanupInactiveSessions, CLEANUP_INTERVAL);
+setInterval(() => {
+  try {
+    cleanupInactiveSessions();
+  } catch (error) {
+    console.error('Error during inactive session cleanup:', error);
+  }
+}, CLEANUP_INTERVAL);
 
 // Helper functions
 function isTokenExpired(tokens) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic cleanup of idle sessions to reduce resource usage and prevent stale connections.
  * Active sessions are preserved via activity tracking; inactive sessions are closed after ~8 minutes.
  * Periodic maintenance runs remove inactive sessions for improved stability and performance.

* **Logging**
  * Startup logs now display the configured session cleanup timeout for easier monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->